### PR TITLE
Change requirements.txt to match pip install pattern

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-OpenCV 4.5.4
-mediapipe 0.8.9.1
-numpy 1.22.2
-pandas 1.4.1
-tk-tools 0.14.0
-PyAutoGUI 0.9.53
-mime 0.1.0
-secure-smtplib 0.1.1
+opencv-python==4.5.4
+mediapipe==0.8
+numpy==1.22
+pandas==1.4
+tk-tools==0.14
+PyAutoGUI==0.9
+mime==0.1
+secure-smtplib==0.1


### PR DESCRIPTION
The current requirements.txt file contains the package name and the version, but we are unable to install them using the requirements file directly. This fix allows the user to install them using pip install -r requirements.txt